### PR TITLE
Fix transition on app resize - closes #51

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,14 +70,21 @@ class MonsterApp extends StatelessWidget {
                 // is not restarted.
                 primarySwatch: Colors.blue,
                 useMaterial3: true),
-            transitionDuration: Duration(
-              milliseconds:
-                  app_screen_util.ScreenUtil().isLargeScreen(context) ? 0 : 300,
-            ),
-            reverseTransitionDuration: Duration(
-              milliseconds:
-                  app_screen_util.ScreenUtil().isLargeScreen(context) ? 0 : 300,
-            ),
+            buildTransition: (animation, secondaryAnimation, child) {
+              if (app_screen_util.ScreenUtil().isLargeScreen(context)) {
+                return child;
+              }
+
+              const begin = Offset(1.0, 0.0);
+              const end = Offset.zero;
+              final tween = Tween(begin: begin, end: end);
+              final offsetAnimation = animation.drive(tween);
+
+              return SlideTransition(
+                position: offsetAnimation,
+                child: child,
+              );
+            },
             initialUrl: "/overview",
             routes: [
               VWidget(


### PR DESCRIPTION
## Proposed changes

Fixes #51. The solution included in this PR leverages the `buildTransition` to return the child widget with no animation on large screens and keep a slide transition on smaller screens.

I've tried several approaches to update the transition duration specifically, though nothing worked. The screen width values and large screen check were being properly evaluated by checking with a breakpoint, it was triggering the rebuild of the main widget, but the transition duration always kept the same value as of the moment the app opens up. It seems that the `VRouter` sets these properties as final when initializing the widget :(

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply.

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No